### PR TITLE
[WIP] 使用 OpenAPI 规范来维护 API 文档

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  title: Bangumi API
+  version: 1.0.0
+servers:
+  -  url: https://api.bgm.tv
+paths:
+  /user/{id}:
+    get:
+      tags:
+        - 用户信息
+      description: 返回用户基础信息
+      responses:
+        200:
+          description: 用户基础信息
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    description: 用户 id
+                    type: integer
+                    example: 1
+                  url:
+                    description: 用户主页地址
+                    type: string
+                  username:
+                    description: 用户名
+                    type: string
+                    example: sai
+                  nickname:
+                    description: 昵称
+                    type: string
+                    example: Sai
+                  avatar:
+                    description: 头像地址
+                    properties:
+                      large:
+                        type: string
+                        example: http://lain.bgm.tv/pic/user/l/000/00/00/1.jpg?r=1391790456
+                      medium:
+                        type: string
+                        example: http://lain.bgm.tv/pic/user/m/000/00/00/1.jpg?r=1391790456
+                      small:
+                        type: string
+                        example: http://lain.bgm.tv/pic/user/s/000/00/00/1.jpg?r=1391790456
+                  sign:
+                    description: TODO
+                    type: string
+                    example: Awesome!


### PR DESCRIPTION
初步的把「用户信息」使用 [OpenAPI 规范](https://swagger.io/specification/)写了一下，暂时可以把 `api.yml` 的内容复制到 https://editor.swagger.io/ 查看渲染后的效果，有文件链接后也可以在 http://petstore.swagger.io/ 输入链接查看。

Sai 老板看下能否使用这种形式来维护文档？可以的话我把其余部分补全。