### PR TITLE
Docs: subject_type是用户收藏概览的必须参数

### DIFF
--- a/docs-raw/User-API.md
+++ b/docs-raw/User-API.md
@@ -43,7 +43,7 @@
 | Parameter | Type | Desc | Note | Required |
 | ------------- | ------------- | ------------- | ------------- | ------------- |
 | username  | string | 用户名 | 也可使用 UID | ☑️ |
-| subject_type  | string | 条目类型 |  (book/anime/music/game/real)  | |
+| subject_type  | string | 条目类型 |  (book/anime/music/game/real)  | ☑️ |
 | max_results  | integer | 显示条数  | 最多 25 | |
 
 # 用户收藏统计


### PR DESCRIPTION
参考资料：https://github.com/bangumi/api/blob/master/open-api/api.yml#L109

试了 `/user/xxxxx/collections`, `/user/xxxxx/collections/` 都提示 404：

```js
{ request: '/user/sai/collections',
  code: 404,
  error: 'Not Found' }
```
```js
{ request: '/user/sai/collections/',
  code: 404,
  error: 'Not Found' }
```