### PR TITLE
修复 /collection/{subject_id}/{action}  参数 status 引用错误的模型

### DIFF
--- a/open-api/api.yml
+++ b/open-api/api.yml
@@ -514,10 +514,10 @@ paths:
               - update
         - name: status
           in: query
-          description: 章节状态，参考 [EpStatusType](#model-EpStatusType)
+          description: 收藏状态，参考 [CollectionStatusType](#model-CollectionStatusType)
           required: true
           schema:
-            $ref: '#/components/schemas/EpStatusType'
+            $ref: '#/components/schemas/CollectionStatusType'
         - name: comment
           in: query
           description: 简评


### PR DESCRIPTION
[Collection-API.md](https://github.com/bangumi/api/blob/master/docs-raw/Collection-API.md) 里参数 status 模型为 [CollectionStatusType](https://bangumi.github.io/api/#model-CollectionStatusType)
```yaml
type: string
    enum:
        - wish
        - collect
        - do
        - on_hold
        - dropped
```


[api.yml](https://github.com/bangumi/api/blob/master/open-api/api.yml)  里参数 status 引用模型 EpStatusType  
https://github.com/bangumi/api/blob/bbb8acac78515f16f4ec3344973361a5d7a504f9/open-api/api.yml#L622-L629


实际测试后，模型应为 [CollectionStatusType](https://bangumi.github.io/api/#model-CollectionStatusType)
